### PR TITLE
Updates to work with Windows platform

### DIFF
--- a/examples/examples.conf.js
+++ b/examples/examples.conf.js
@@ -1,4 +1,9 @@
 const enhancedEcommerceSchema = require('../lib/enhancedEcommerceSchema.json')
+const isWin = /^win/.test(process.platform);
+var phantomjsBinaryPath = './node_modules/.bin/phantomjs';
+if(isWin)
+	phantomjsBinaryPath = './node_modules/.bin/phantomjs.cmd';
+	
 exports.config = {
     specs: [
         './examples/spec/basic_example.js'
@@ -7,7 +12,7 @@ exports.config = {
     capabilities: [{
         maxInstances: 5,
         browserName: 'phantomjs',
-        'phantomjs.binary.path': './node_modules/phantomjs-prebuilt/bin/phantomjs'
+        'phantomjs.binary.path': phantomjsBinaryPath
     }],
     sync: true,
     logLevel: 'silent',
@@ -23,6 +28,7 @@ exports.config = {
     seleniumArgs: {
         version: '3.0.1'
     },
+	seleniumLogs: "sellogs/",
     framework: 'mocha',
     reporters: ['spec'],
     mochaOpts: {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "spec": "wdio ./examples/examples.conf.js",
     "start": "http-server ./examples -s",
     "test": "npm start & npm run spec -s || true",
+	"testwin": "start npm start & npm run spec -s || true",
     "posttest": "pkill -f http-server",
     "postinstall": "cd node_modules/wdio-spec-reporter/ && npm install"
   },


### PR DESCRIPTION
Instead of 'npm test' need to use 'npm run-script testwin'
Also a seperate window for the Selenium server gets opened and needs to be killed manually as pkill does not work in windows
Added writing of Slenium logs to a folder for debugging purpose